### PR TITLE
Fix blueprint for scoped package names

### DIFF
--- a/.changeset/nice-shrimps-notice.md
+++ b/.changeset/nice-shrimps-notice.md
@@ -1,0 +1,5 @@
+---
+"ember-addon-migrator": patch
+---
+
+Fix an issue where an addon has a scoped package name, ember-cli will turn the package name into a dasherized version of it as the addon location, which then would not match the location we were expecting. This happened when generating the temporary addon that files get pulled from for migration / merging with the existing addon.

--- a/cli/src/v2-blueprint.js
+++ b/cli/src/v2-blueprint.js
@@ -22,8 +22,13 @@ export async function installV2Blueprint(info) {
     : '';
   let ts = info.isTS ? '--typescript' : '';
 
+  // we'll create the addon here instead of using a directory based on the actual name, as this is temporary anyway
+  // and prevents issues with scoped package names getting in some way dasherized by ember-cli
+  let addonDir = 'addon';
+
   await execaCommand(
     `npx ember-cli@^4.10.0 addon ${info.name}` +
+      ` --dir=${addonDir}` +
       ` --blueprint @embroider/addon-blueprint` +
       // ` --blueprint ../addon-blueprint` +
       ` --test-app-location=${info.testAppLocation}` +
@@ -40,7 +45,7 @@ export async function installV2Blueprint(info) {
     }
   );
 
-  let generatedLocation = path.join(tmp, info.name);
+  let generatedLocation = path.join(tmp, addonDir);
   let generatedFiles = await fs.readdir(generatedLocation);
 
   for (let current of generatedFiles) {

--- a/tests/fixtures/base-js-v1-addon/package.json
+++ b/tests/fixtures/base-js-v1-addon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "base-v1-addon",
+  "name": "@NullVoxPopuli/base-v1-addon",
   "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [

--- a/tests/fixtures/base-js-v1-addon/package.json
+++ b/tests/fixtures/base-js-v1-addon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@NullVoxPopuli/base-v1-addon",
+  "name": "@some/base-v1-addon",
   "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [

--- a/tests/fixtures/base-js-v1-addon/tests/unit/sample-test.js
+++ b/tests/fixtures/base-js-v1-addon/tests/unit/sample-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-import { two } from 'base-v1-addon';
+import { two } from '@some/base-v1-addon';
 
 module('sample', function (hooks) {
   setupTest(hooks);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -77,7 +77,8 @@ export async function addonFrom(fixture: string): Promise<Project> {
   let originalPackageJsonPath = path.join(fixturePath, 'package.json');
   let originalPackageJson = await fse.readJSON(originalPackageJsonPath);
 
-  let projectName = originalPackageJson.name;
+  let projectName =
+    originalPackageJson.name.split('/')[1] ?? originalPackageJson.name;
 
   await fs.cp(fixturePath, tmp, { recursive: true });
 


### PR DESCRIPTION
When the addon has a scoped package name, then ember-cli will turn that into a somehow dasherized version of it as the addon location, which then did not match the location we were expecting.