### PR TITLE
fix: Rename pacakge to package as the default name for src code

### DIFF
--- a/.changeset/blue-masks-double.md
+++ b/.changeset/blue-masks-double.md
@@ -1,0 +1,5 @@
+---
+"ember-addon-migrator": patch
+---
+
+Fix typo in default package directory name when --addon-location is omitted

--- a/cli/src/analysis/index.js
+++ b/cli/src/analysis/index.js
@@ -251,7 +251,7 @@ export class AddonInfo {
    */
   get addonLocation() {
     if (this.isBiggerMonorepo) {
-      return this.#options.addonLocation || 'pacakge';
+      return this.#options.addonLocation || 'package';
     }
 
     return (


### PR DESCRIPTION
Fixes: https://github.com/NullVoxPopuli/ember-addon-migrator/issues/59

I believe this is a typo.

## Before
<img width="413" alt="Screenshot 2023-06-01 at 5 50 18 PM" src="https://github.com/NullVoxPopuli/ember-addon-migrator/assets/771170/8b43e000-d5fb-49dd-80fa-b4c139a78b27">

Moves package code into a folder named `pacakge` which I think is a typo.

