### PR TITLE
Add options for `extract-tests` to reuse existing versions or ignore new dependencies

### DIFF
--- a/.changeset/happy-ties-search.md
+++ b/.changeset/happy-ties-search.md
@@ -1,0 +1,14 @@
+---
+"ember-addon-migrator": minor
+---
+
+Two new flags for managing dependencies:
+
+- `--reuse-existing-versions`
+  When the test-app is generated, instead of using the (latest) dependency versions of the app blueprint it will try to use the same versions previously used in the addon.
+
+- `--ignore-new-dependencies`
+  When the test-app is generated, any dependencies that are part of the default app blueprint which were not used before will be ignored. WARNING: there is a considerable risk that this leaves your dependencies in a broken state, use it only with great caution!
+
+These two flags are available for both the default command (run), and extract-tests.
+See `--help` for more information.

--- a/cli/bin.js
+++ b/cli/bin.js
@@ -90,6 +90,18 @@ yarg
         type: 'boolean',
         default: false,
       });
+      yargs.option('reuse-existing-versions', {
+        describe:
+          'When the test-app is generated, instead of using the (latest) dependency versions of the app blueprint it will try to use the same versions previously used in the addon.',
+        type: 'boolean',
+        default: false,
+      });
+      yargs.option('ignore-new-dependencies', {
+        describe:
+          'When the test-app is generated, any dependencies that are part of the default app blueprint which were not used before will be ignored. WARNING: there is a considerable risk that this leaves your dependencies in a broken state, use it only with great caution!',
+        type: 'boolean',
+        default: false,
+      });
     },
     async (args) => {
       // "Light logic" to keep the test app to be a sibling to the addon directory (if not specified)
@@ -133,6 +145,18 @@ yarg
       });
       yargs.option('analysis-only', {
         describe: 'inspect the analysis object, skipping migration entirely',
+        type: 'boolean',
+        default: false,
+      });
+      yargs.option('reuse-existing-versions', {
+        describe:
+          'When the test-app is generated, instead of using the (latest) dependency versions of the app blueprint it will try to use the same versions previously used in the addon.',
+        type: 'boolean',
+        default: false,
+      });
+      yargs.option('ignore-new-dependencies', {
+        describe:
+          'When the test-app is generated, any dependencies that are part of the default app blueprint which were not used before will be ignored. WARNING: there is a considerable risk that this leaves your dependencies in a broken state, use it only with great caution!',
         type: 'boolean',
         default: false,
       });

--- a/cli/src/analysis/index.js
+++ b/cli/src/analysis/index.js
@@ -299,6 +299,17 @@ export class AddonInfo {
   hasDevDependency = (dep) => {
     return Boolean(this.packageJson.devDependencies?.[dep]);
   };
+
+  /**
+   * get the version specifier of an existing dependency
+   * @param {string} dep
+   */
+  versionForDependency = (dep) => {
+    return (
+      this.packageJson.dependencies?.[dep] ??
+      this.packageJson.devDependencies?.[dep]
+    );
+  };
 }
 
 /**

--- a/cli/src/extract-tests/index.js
+++ b/cli/src/extract-tests/index.js
@@ -62,7 +62,7 @@ export default async function extractTests(args) {
 
         tasks.push({
           title: `Moving files from the addon to the test-app`,
-          task: () => migrateTestApp(analysis),
+          task: () => migrateTestApp(analysis, args),
         });
 
         tasks.push({

--- a/cli/src/extract-tests/types.ts
+++ b/cli/src/extract-tests/types.ts
@@ -1,4 +1,7 @@
-export interface Args {
+// eslint-disable-next-line n/no-missing-import
+import type { TestAppOptions } from '../types';
+
+export interface Args extends TestAppOptions {
   testAppLocation: string;
   directory: string;
   inPlace?: boolean;

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -16,7 +16,7 @@ import { installV2Blueprint } from './v2-blueprint.js';
 import { install, updateRootFiles } from './workspaces.js';
 
 /**
- * @param {import('./analysis/types').Options} options
+ * @param {import('./types').Options} options
  */
 export default async function run(options) {
   await verifyOptions(options);
@@ -67,7 +67,7 @@ export default async function run(options) {
             },
             {
               title: 'Migrating test files',
-              task: () => migrateTestApp(analysis),
+              task: () => migrateTestApp(analysis, options),
             },
           ]);
         },

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,0 +1,12 @@
+export interface TestAppOptions {
+  reuseExistingVersions: boolean;
+  ignoreNewDependencies: boolean;
+}
+
+export interface Options extends TestAppOptions {
+  analysisOnly: boolean;
+  addonLocation: string;
+  testAppLocation: string;
+  testAppName: string;
+  directory: string;
+}


### PR DESCRIPTION
This is an attempt to implement the use cases of #64.

`--reuse-existing-versions` will replace any version specifier of the test-app with the one that existed before the migration, e.g. a pinned one. 

`--ignore-new-dependencies` will remove dependencies from test-app if they weren't in use before. This is admittedly a high risk option, in case we remove things that are not optional and do not come from "elsewhere" (like centralized linting configs), but it worked out quite ok for us...

No test coverage here, idk if you like to see some for these flags? Would need to be some fixture-based tests that actually assert file contents instead of "just" doing some smoke-tests that the migration results passes linting/tests, right? (Tbh, I wouldn't mind not having to do those, at least at this stage of this project... 🙃)

/cc @nicolechung 