### PR TITLE
extract-tests: remove unused test scripts and devDeps from addon

### DIFF
--- a/.changeset/smart-years-pretend.md
+++ b/.changeset/smart-years-pretend.md
@@ -1,0 +1,6 @@
+---
+"ember-addon-migrator": patch
+---
+
+extract-tests: remove unused test scripts and devDeps from addon
+As the addon does not contain any tests anymore, we can remove package.json scripts and devDependencies that relate to testing.

--- a/cli/src/extract-tests/index.js
+++ b/cli/src/extract-tests/index.js
@@ -267,9 +267,7 @@ async function cleanupAddon(analysis) {
   await packageJson.modify((json) => {
     // Remove any test-related scripts, as they now will be in the test-app
     json.scripts = Object.fromEntries(
-      Object.entries(json.scripts).filter(
-        ([key]) => !key.includes('test')
-      )
+      Object.entries(json.scripts).filter(([key]) => !key.includes('test'))
     );
 
     // Remove testing dependencies from devDependencies, unless they are in peerDependencies, which means the addon's own code (e.g. /addon-test-support) might need them

--- a/cli/src/extract-tests/index.js
+++ b/cli/src/extract-tests/index.js
@@ -268,7 +268,7 @@ async function cleanupAddon(analysis) {
     // Remove any test-related scripts, as they now will be in the test-app
     json.scripts = Object.fromEntries(
       Object.entries(json.scripts).filter(
-        ([key]) => key !== 'test' && key !== '_test' && !key.match(/^test:.*/)
+        ([key]) => !key.includes('test')
       )
     );
 

--- a/tests/fixtures/base-ts-v1-addon/package.json
+++ b/tests/fixtures/base-ts-v1-addon/package.json
@@ -14,8 +14,10 @@
   },
   "typesVersions": {
     "*": {
-      "*": ["./addon/*"]
-    } 
+      "*": [
+        "./addon/*"
+      ]
+    }
   },
   "scripts": {
     "build": "ember build --environment=production",
@@ -40,7 +42,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.6.0",
+    "@ember/test-helpers": "^2.9.4",
     "@embroider/test-setup": "^0.49.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
@@ -61,7 +63,6 @@
     "@types/ember__string": "^3.0.9",
     "@types/ember__template": "^4.0.0",
     "@types/ember__test": "^4.0.0",
-    "@types/ember__test-helpers": "^2.6.1",
     "@types/ember__utils": "^4.0.0",
     "@types/htmlbars-inline-precompile": "^3.0.0",
     "@types/qunit": "^2.11.3",


### PR DESCRIPTION
As the addon does not contain any tests anymore, we can remove package.json scripts and devDependencies that relate to testing.