### PR TITLE
extract-tests: Fix copying files for test app

### DIFF
--- a/.changeset/giant-cycles-attend.md
+++ b/.changeset/giant-cycles-attend.md
@@ -1,0 +1,13 @@
+---
+"ember-addon-migrator": minor
+---
+
+Add new flag, `--reuse-existing-configs` to both the default command and `extract-tests`
+
+When used, this will copy the existing configs to the new test-app, rather than using the defaults.
+This is helpful for when a project's configs are resilient to directory and project changes.
+
+For examples of such configs, see:
+
+- https://github.com/NullVoxPopuli/eslint-configs
+- https://github.com/embroider-build/addon-blueprint/issues/71#issuecomment-1341912431

--- a/cli/bin.js
+++ b/cli/bin.js
@@ -102,6 +102,12 @@ yarg
         type: 'boolean',
         default: false,
       });
+      yargs.option('reuse-existing-configs', {
+        describe:
+          'When the test-app is generated, existing config files like .eslintrc.js will be reused for the test-app, instead of the default configs coming form the app blueprint.',
+        type: 'boolean',
+        default: false,
+      });
     },
     async (args) => {
       // "Light logic" to keep the test app to be a sibling to the addon directory (if not specified)
@@ -157,6 +163,12 @@ yarg
       yargs.option('ignore-new-dependencies', {
         describe:
           'When the test-app is generated, any dependencies that are part of the default app blueprint which were not used before will be ignored. WARNING: there is a considerable risk that this leaves your dependencies in a broken state, use it only with great caution!',
+        type: 'boolean',
+        default: false,
+      });
+      yargs.option('reuse-existing-configs', {
+        describe:
+          'When the test-app is generated, existing config files like .eslintrc.js will be reused for the test-app, instead of the default configs coming form the app blueprint.',
         type: 'boolean',
         default: false,
       });

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,6 +1,7 @@
 export interface TestAppOptions {
   reuseExistingVersions: boolean;
   ignoreNewDependencies: boolean;
+  reuseExistingConfigs: boolean;
 }
 
 export interface Options extends TestAppOptions {


### PR DESCRIPTION
There was some functionality to move existing configs to the test-app, but it had the wrong path for the source files, and the files shouldn't be moved but copied, to not remove them from the addon.

As that behaviour might not always be want you want, this is now behind a CLI flag.

Would that effectively fix https://github.com/NullVoxPopuli/ember-addon-migrator/issues/68? 