### PR TITLE
extract-tests: add `--skip-ember-try` flag

### DIFF
--- a/cli/bin.js
+++ b/cli/bin.js
@@ -108,6 +108,11 @@ yarg
         type: 'boolean',
         default: false,
       });
+      yargs.option('skip-ember-try', {
+        describe: 'Do not set up ember-try for the generated test-app.',
+        type: 'boolean',
+        default: false,
+      });
     },
     async (args) => {
       // "Light logic" to keep the test app to be a sibling to the addon directory (if not specified)

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -2,6 +2,7 @@ export interface TestAppOptions {
   reuseExistingVersions: boolean;
   ignoreNewDependencies: boolean;
   reuseExistingConfigs: boolean;
+  skipEmberTry: boolean;
 }
 
 export interface Options extends TestAppOptions {


### PR DESCRIPTION
You might not want ember-try e.g. in a monorepo.