### PR TITLE
extract-tests: copy eventual tailwind.config.js

### DIFF
--- a/cli/src/test-app.js
+++ b/cli/src/test-app.js
@@ -42,6 +42,7 @@ async function moveFilesToTestApp(info) {
     '.eslintrc.js',
     '.stylelintrc.js',
     '.stylelintignore',
+    'tailwind.config.js',
   ];
 
   await Promise.allSettled([


### PR DESCRIPTION
Even though the config is not part of the default setup, I think it wouldn't hurt to include it when copying configs to the test-app in case it exists.