### PR TITLE
Fix copying test files

### DIFF
--- a/.changeset/tiny-meals-push.md
+++ b/.changeset/tiny-meals-push.md
@@ -1,0 +1,7 @@
+---
+'ember-addon-migrator': patch
+---
+
+Fix copying test files
+
+At a previous iteration a regression was introduced, that copied the test files into the test-app, but including their full path. This is fixed now.

--- a/cli/src/test-app.js
+++ b/cli/src/test-app.js
@@ -244,15 +244,19 @@ async function moveTestsAndDummyApp(info, options) {
   );
   await fse.remove(path.join(info.tmpLocation, 'tests/dummy'));
 
-  const paths = await globby([path.join(info.tmpLocation, 'tests/**/*')], {
+  const paths = await globby(['tests/**/*'], {
     cwd: info.tmpLocation,
     gitignore: true,
   });
 
   for (let filePath of paths) {
-    await fse.move(filePath, path.join(info.testAppLocation, filePath), {
-      overwrite: true,
-    });
+    await fse.move(
+      path.join(info.tmpLocation, filePath),
+      path.join(info.testAppLocation, filePath),
+      {
+        overwrite: true,
+      }
+    );
 
     await ensureNoJsTsDuplicates(info, filePath);
   }


### PR DESCRIPTION
At a previous iteration a regression was introduced, that copied the test files into the test-app, but including their full path:

![image](https://github.com/NullVoxPopuli/ember-addon-migrator/assets/1325249/667bc6d1-53f5-4047-bd6b-5ba683041886)
