### PR TITLE
Add `--exclude-tests` to support two-phased migration

### DIFF
--- a/cli/bin.js
+++ b/cli/bin.js
@@ -154,6 +154,13 @@ yarg
         type: 'string',
         default: process.cwd(),
       });
+      yargs.option('exclude-tests', {
+        alias: 'in-place',
+        describe:
+          'Do not try to migrate tests. Useful when having run the extract-tests command before',
+        type: 'boolean',
+        default: false,
+      });
       yargs.option('analysis-only', {
         describe: 'inspect the analysis object, skipping migration entirely',
         type: 'boolean',

--- a/cli/src/addon.js
+++ b/cli/src/addon.js
@@ -13,8 +13,9 @@ import { prepare } from './prepare.js';
 
 /**
  * @param {Info} info
+ * @param {import('./types').Options} options
  */
-export async function migrateAddon(info) {
+export async function migrateAddon(info, options) {
   let addonFolder = path.join(info.tmpLocation, 'addon');
   let testSupportFolder = path.join(info.tmpLocation, 'addon-test-support');
 
@@ -136,7 +137,7 @@ async function updateAddonPackageJson(info) {
   }
 
   await fs.writeFile(
-    `${info.addonLocation}/package.json`,
+    path.join(info.addonLocation, 'package.json'),
     JSON.stringify(pJson, null, 2)
   );
 }

--- a/cli/src/analysis/index.js
+++ b/cli/src/analysis/index.js
@@ -250,6 +250,10 @@ export class AddonInfo {
    *   (because <directory> usually ends with some form of the addon-name)
    */
   get addonLocation() {
+    if (this.#options.excludeTests) {
+      return '';
+    }
+
     if (this.isBiggerMonorepo) {
       return this.#options.addonLocation || 'package';
     }

--- a/cli/src/analysis/types.ts
+++ b/cli/src/analysis/types.ts
@@ -6,6 +6,7 @@ export interface Options {
   testAppLocation: string;
   testAppName: string;
   directory: string;
+  excludeTests: boolean;
 }
 
 interface Volta {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -53,20 +53,22 @@ export default async function run(options) {
             },
             {
               title: 'Installing the V2 Addon Blueprint',
-              task: () => installV2Blueprint(analysis),
+              task: () => installV2Blueprint(analysis, options),
             },
             {
               title: `Updating addon's root files`,
+              skip: () => options.excludeTests,
               task: () => updateRootFiles(analysis),
             },
             {
               title: 'Migrating addon files',
               task: () => {
-                return migrateAddon(analysis);
+                return migrateAddon(analysis, options);
               },
             },
             {
               title: 'Migrating test files',
+              skip: () => options.excludeTests,
               task: () => migrateTestApp(analysis, options),
             },
           ]);
@@ -86,6 +88,7 @@ export default async function run(options) {
             },
             {
               title: `lint:fix on test app`,
+              skip: () => options.excludeTests,
               task: () => lintFix(analysis, analysis.testAppLocation),
             },
           ]);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -11,4 +11,5 @@ export interface Options extends TestAppOptions {
   testAppLocation: string;
   testAppName: string;
   directory: string;
+  excludeTests: boolean;
 }

--- a/cli/src/v2-blueprint.js
+++ b/cli/src/v2-blueprint.js
@@ -10,8 +10,9 @@ import { createTmp } from './prepare.js';
 
 /**
  * @param {Info} info
+ * @param {import('./types').Options} options
  */
-export async function installV2Blueprint(info) {
+export async function installV2Blueprint(info, options) {
   let tmp = await createTmp('v2-addon-creation--');
   let packager = info.isPnpm
     ? '--pnpm'
@@ -41,6 +42,7 @@ export async function installV2Blueprint(info) {
       '--skip-npm',
       // We want to use the existing git
       '--skip-git',
+      options.excludeTests ? '--addon-only' : undefined,
     ].filter(Boolean),
     {
       cwd: tmp,

--- a/cli/src/workspaces.js
+++ b/cli/src/workspaces.js
@@ -38,7 +38,7 @@ export async function install(info, options = {}) {
 export async function updateRootFiles(info) {
   /**
    * If we're in a bigger monorepo, we need to remove the
-   * known monorepeo root files, because they likely exist elsewhere.
+   * known monorepo root files, because they likely exist elsewhere.
    */
   if (info.isBiggerMonorepo) {
     await fse.rm(path.join(info.directory, 'package.json'));

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -3,12 +3,14 @@ import { expect } from 'vitest';
 
 import { type Project, binPath, emberTest } from './helpers.js';
 
-export async function migrate(project: Pick<Project, 'rootPath'>) {
+export async function migrate(rootPath: string, flags: Array<string> = []) {
   console.debug('To Debug:');
-  console.debug(`  within: ${project.rootPath}`);
-  console.debug(`node ${binPath}`);
+  console.debug(`  within: ${rootPath}`);
+  console.debug(`node ${binPath} ${flags.join(' ')}`);
 
-  let { stdout } = await execa('node', [binPath], { cwd: project.rootPath });
+  let { stdout } = await execa('node', [binPath, ...flags], {
+    cwd: rootPath,
+  });
 
   expect(stdout).toMatch(
     `🎉 Congratulations! Your addon is now formatted as a V2 addon!`
@@ -16,15 +18,15 @@ export async function migrate(project: Pick<Project, 'rootPath'>) {
 }
 
 export async function makeMonorepo(
-  project: Pick<Project, 'rootPath'>,
+  rootPath: string,
   flags: Array<string> = []
 ) {
   console.debug('To Debug:');
-  console.debug(`  within: ${project.rootPath}`);
+  console.debug(`  within: ${rootPath}`);
   console.debug(`node ${binPath} make-monorepo ${flags.join(' ')}`);
 
   let { stdout } = await execa('node', [binPath, 'make-monorepo', ...flags], {
-    cwd: project.rootPath,
+    cwd: rootPath,
   });
 
   expect(stdout).toMatch(
@@ -33,15 +35,15 @@ export async function makeMonorepo(
 }
 
 export async function extractTests(
-  project: Pick<Project, 'rootPath'>,
+  rootPath: string,
   flags: Array<'--in-place' | string> = []
 ) {
   console.debug('To Debug:');
-  console.debug(`  within: ${project.rootPath}`);
+  console.debug(`  within: ${rootPath}`);
   console.debug(`node ${binPath} extract-tests ${flags.join(' ')}`);
 
   let { stdout } = await execa('node', [binPath, 'extract-tests', ...flags], {
-    cwd: project.rootPath,
+    cwd: rootPath,
   });
 
   expect(stdout).toMatch(
@@ -49,8 +51,8 @@ export async function extractTests(
   );
 }
 
-export async function assertEmberTest(project: Pick<Project, 'testAppPath'>) {
-  let { stdout, exitCode } = await emberTest(project);
+export async function assertEmberTest(testAppPath: string) {
+  let { stdout, exitCode } = await emberTest(testAppPath);
 
   // subset of full stdout
   // can't use snapshot testing due to time taken printed

--- a/tests/tests/make-monorepo.test.ts
+++ b/tests/tests/make-monorepo.test.ts
@@ -17,8 +17,8 @@ describe(`make-monorepo on fixture: ${fixtureName}`, () => {
     assert(fixtureName, 'No fixtures found');
 
     project = await addonFrom(fixtureName);
-    await makeMonorepo(project);
-    await install(project);
+    await makeMonorepo(project.rootPath);
+    await install(project.rootPath);
   });
 
   test('verify tmp project', async () => {
@@ -45,6 +45,6 @@ describe(`make-monorepo on fixture: ${fixtureName}`, () => {
   });
 
   test('tests pass', async () => {
-    assertEmberTest({ testAppPath: project.addonPath });
+    assertEmberTest(project.addonPath);
   });
 });

--- a/tests/tests/two-phase-migration.test.ts
+++ b/tests/tests/two-phase-migration.test.ts
@@ -2,26 +2,32 @@ import { execa } from 'execa';
 import fse from 'fs-extra';
 import { beforeAll, describe, expect, test } from 'vitest';
 
-import { assertEmberTest, migrate } from '../assertions.js';
+import { assertEmberTest, extractTests, migrate } from '../assertions.js';
 import {
   type Project,
   addonFrom,
   build,
   findFixtures,
+  install,
   lintAddon,
   lintTestApp,
+  makeMonorepo,
 } from '../helpers.js';
 
 let fixtures = await findFixtures();
 
 for (let fixtureName of fixtures) {
-  describe(`default command on fixture: ${fixtureName}`, () => {
+  describe(`extract-tests + --exclude-tests on fixture: ${fixtureName}`, () => {
     let project: Project;
 
     beforeAll(async () => {
       project = await addonFrom(fixtureName);
-      await migrate(project.rootPath);
-      await build(project.addonPath);
+      await extractTests(project.rootPath, ['--no-in-place']);
+      await makeMonorepo(project.rootPath);
+      await install(project.rootPath);
+      await migrate(project.packagePath, ['--exclude-tests']);
+      await install(project.rootPath);
+      await build(project.packagePath);
     });
 
     test('verify tmp project', async () => {
@@ -34,8 +40,8 @@ for (let fixtureName of fixtures) {
         `rootPath: ${project.rootPath}`
       ).toBe(true);
       expect(
-        await fse.pathExists(project.addonPath),
-        `addonPath: ${project.addonPath}`
+        await fse.pathExists(project.packagePath),
+        `addonPath: ${project.packagePath}`
       ).toBe(true);
       expect(
         await fse.pathExists(project.testAppPath),
@@ -44,7 +50,7 @@ for (let fixtureName of fixtures) {
     });
 
     test('lint addon', async () => {
-      let result = await lintAddon(project.addonPath);
+      let result = await lintAddon(project.packagePath);
 
       expect(result).toMatchObject({ exitCode: 0 });
     });


### PR DESCRIPTION
When running `extract-tests`, you would want to migrate to v2 without touching the test-app again. The Readme says:

> Do an in-place conversion of the v1 addon in "sub-folder" to a v2 addon. The default command for ember-addon-migrator will do this for you via --exclude-tests or --in-place (these flags are aliases of each-other)

But these flags didn't exist yet. This PR adds them! :)